### PR TITLE
Add auto deploy of docker images via github actions 

### DIFF
--- a/.github/main_ci.yml
+++ b/.github/main_ci.yml
@@ -1,0 +1,56 @@
+name: CI to Docker Hub 
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      -       
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/behat
+          tag-sha: true
+      -     
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - 
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ 
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Wellnet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+<br/>
+<p align="center">
+    <a href="https://github.com/wellnet/behat/releases" target="_blank">
+        <img src="https://img.shields.io/github/v/tag/wellnet/behat" alt="GitHub tag (latest SemVer)">
+    </a>
+    <a href="https://github.com/wellnet/behat/actions" target="_blank">
+        <img src="https://img.shields.io/github/workflow/status/wellnet/behat/CI%20to%20Docker%20Hub" alt="Workflow status">
+    </a>
+    <a href="https://github.com/wellnet/behat/graphs/contributors" target="_blank">
+        <img src="https://img.shields.io/github/contributors/wellnet/behat" alt="GitHub contributors">
+    </a>
+</p>
+<br/>
+
+[Behat](https://github.com/Behat/Behat) is a Behat is a BDD framework for PHP to help you test business expectations.
+
+This repository contains a specific Docker image used by [Wellnet](http://wellnet.it) in some projects. Use at your own risk!
+
+<br/>
+
+
+## 👨‍💻&nbsp; Installation
+
+Install via Docker Hub: `docker pull wellnetimages/behat`
+
+## 🚀&nbsp; Deploy
+
+```
+# Add files to the repository
+git add .
+git commit -m "Description of the changes"
+
+# Add a version
+git tag -a v*.*.*
+
+# Push code and tag
+git push origin master --tags
+```
+
+
+## ❤️&nbsp; Contributions
+
+If you want to contribute, just add a PR or open a new issue.
+
+
+## 📘&nbsp; License
+
+Behat is under [MIT license](https://github.com/Behat/Behat/blob/master/LICENSE), and also this repository.


### PR DESCRIPTION
This PR adds:

- Github Actions integration for auto-deploy of the docker image 
- a simple README
- a MIT license

In order to enable the workflow auto-deploy on Docker Hub, two Github Secrets needs to be set: `DOCKER_HUB_ACCESS_TOKEN` and `DOCKER_HUB_USERNAME`. The first one must be enabled from the DockerHub account in Account Settings -> Security -> Access Token. The second one is `wellnetimages`.

This PR is made in order to keeping track of the changes and leave some documentation :)