### PR TITLE
Add missing Subscribed Event that causes wrong duration in reports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,12 @@
   },
   "config": {
     "bin-dir": "bin/"
+  },
+  "extra": {
+    "patches": {
+      "vanare/behat-cucumber-json-formatter": {
+        "Fix duration output": "patches/fix_duration_output.patch"
+      }
+    }
   }
 }

--- a/patches/fix_duration_output.patch
+++ b/patches/fix_duration_output.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Formatter/Formatter.php b/src/Formatter/Formatter.php
+index 4f19ea4..4daed1e 100644
+--- a/src/Formatter/Formatter.php
++++ b/src/Formatter/Formatter.php
+@@ -133,6 +133,7 @@ class Formatter implements FormatterInterface
+             'tester.scenario_tested.after' => 'onAfterScenarioTested',
+             'tester.outline_tested.before' => 'onBeforeOutlineTested',
+             'tester.outline_tested.after' => 'onAfterOutlineTested',
++            'tester.step_tested.before' => 'onBeforeStepTested',
+             'tester.step_tested.after' => 'onAfterStepTested',
+         );
+     }
+


### PR DESCRIPTION
This solves a really old (2016) bug in Behat Cucumber Formatter, never fixed.

When Behat Cucumber Formatter calculate the duration of the tests, it loads the monitored events via getSubscribedEvents() function.

This function has an After step`'tester.step_tested.after' => 'onAfterStepTested'` but not a Before step `'tester.step_tested.before' => 'onBeforeStepTested'`

Adding the Before step allows the export the right duration in reports.
